### PR TITLE
Replace python-certifi-win32

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     numpy>=1,<2
     requests>=2,<3
     pyaml>=20,<22
-    python-certifi-win32
+    pip_system_certs
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
python-certifi-win32 has been replaced by pip-system-certs and is generally unmaintained.